### PR TITLE
bumped versions in requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # Other
 .DS_Store
+.vscode/settings.json 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 appdirs==1.4.4
-autopep8==1.5.2
-Cython==0.29.19
-distlib==0.3.0
+autopep8==1.5.4
+Cython==0.29.21
+distlib==0.3.1
 filelock==3.0.12
-flake8==3.8.2
+flake8==3.8.4
 future==0.18.2
-iso8601==0.1.12
+iso8601==0.1.13
 mccabe==0.6.1
-numpy==1.18.4
-pandas==0.24.2
+pandas==1.1.4
 pycodestyle==2.6.0
 pyflakes==2.2.0
+pyserial==3.5
 python-dateutil==2.8.1
-pytz==2020.1
+pytz==2020.4
 PyYAML==5.3.1
-serial==0.0.97
-six==1.14.0
-virtualenv==20.0.20
+# serial==0.0.97 # name conflict with pyserial (included as just 'serial')
+six==1.15.0
+# virtualenv==20.0.20 # virtualenv is deprecated in favour of 'python -m venv' 


### PR DESCRIPTION
Bumped versions of all dependencies to latest versions.

please note the significance of virtualenv, and serial within requirements.txt. Pyserial and serial both carry the same name in python, causing a name conflict. I couldn't tell what serial was exactly used for but the program runs as expected without it. 